### PR TITLE
change sulu requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "require": {
         "php": "^5.5 || ^7.0",
-        "sulu/sulu": "dev-develop",
+        "sulu/sulu": "^1.4",
         "sulu/document-manager": "@dev",
         "massive/search-bundle": "@dev",
         "ongr/elasticsearch-bundle": "~1.0"


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

A change in composer.json to enable usage of the bundle using a stable version of sulu

#### Why?

By default it requires sulu/sulu `dev-develop` because there is no release yet.


